### PR TITLE
Feature/specify score and weight locations

### DIFF
--- a/CPL/trainers/cocoopcf.py
+++ b/CPL/trainers/cocoopcf.py
@@ -193,7 +193,7 @@ def cfgen(x, nx, u, y, use_cuda=True):
 
 #
 from utils import *
-def init_score_dict(classnames):
+def init_score_dict(classnames, output_dir):
     ScoreDict = {}
     
     list1 = [v for v in classnames for _ in range(len(classnames))]
@@ -202,7 +202,7 @@ def init_score_dict(classnames):
     scorelist = [Flist[i:i + len(classnames)] for i in range(0, len(ref), len(classnames))]
     for index, i in enumerate(classnames):
         ScoreDict[i] = classnames[scorelist[index].topk(2, dim=0)[1][1]]
-    np.save('score.npy', ScoreDict)
+    np.save(osp.join(output_dir, "score.npy"), ScoreDict)
     return ScoreDict
 
 
@@ -217,8 +217,10 @@ class CustomCLIP(nn.Module):
         self.dtype = clip_model.dtype
         self.classnames = classnames
         self.vis_dim = clip_model.visual.output_dim
-        self.ScoreDict = init_score_dict(classnames)    ## generate score dictionary
-        # self.ScoreDict = np.load('score.npy', allow_pickle=True).item()
+        self.ScoreDict = init_score_dict(classnames, cfg.OUTPUT_DIR)    ## generate score dictionary
+        # self.ScoreDict = np.load(
+        #     osp.join(cfg.OUTPUT_DIR, "score.npy"), allow_pickle=True
+        # ).item()
 
 
     def forward(self, image, ustar=None, nimgs=None, label=None):
@@ -313,8 +315,9 @@ class CoCoOpcf(TrainerX):
 
         self.scaler = GradScaler() if cfg.TRAINER.COCOOP.PREC == "amp" else None
 
-
-        self.ScoreDict = np.load('score.npy', allow_pickle=True).item()
+        self.ScoreDict = np.load(
+            osp.join(cfg.OUTPUT_DIR, "score.npy"), allow_pickle=True
+        ).item()
         print(f"Loading score dictionary")
 
 

--- a/CPL/utils/solver.py
+++ b/CPL/utils/solver.py
@@ -51,14 +51,17 @@ def get_next_edit(feat_original, feat_target, label, model, lab2cname, ntext_fea
 
 def solver(model, image, nimg, label, lab2cname):
     args, config = set_args()
-    dataset = args.root.split('/')[-1]
-    if os.path.exists(f'weights/{dataset}_{args.seed}_{args.opts}.pth'): 
+    dataset = config.DATASET.NAME
+    weight_dir = os.path.join(config.OUTPUT_DIR, "weights")
+    os.makedirs(weight_dir, exist_ok=True)
+
+    if os.path.exists(f"{weight_dir}/{dataset}_{args.seed}_{args.opts}.pth"):
         print('load weights')
-        return torch.load(f'weights/{dataset}_{args.seed}_{args.opts}.pth')
+        return torch.load(f"{weight_dir}/{dataset}_{args.seed}_{args.opts}.pth")
     else:
         if config.COCOOPCF == "true":
             u, ep = trained_solver(model, image, nimg, label, args)
-            torch.save(u.t().repeat(4, 1), f'weights/{dataset}_{args.seed}_{args.opts}_{ep}.pth')
+            torch.save(u.t().repeat(4, 1), f"{weight_dir}/{dataset}_{args.seed}_{args.opts}_{ep}.pth")
             return u
         else:
             dtype = model.dtype
@@ -68,7 +71,9 @@ def solver(model, image, nimg, label, lab2cname):
                 distractor_features = model.visual(nimg.type(dtype).cuda()).cuda()
 
                 # lab2cname =  np.load('lab2cname.npy', allow_pickle=True).item()       # replace and load the corresponding preprocessed label to classnames dictionary in the root path
-                ScoreDict = np.load('score.npy', allow_pickle=True).item()
+                ScoreDict = np.load(
+                    os.path.join(config.OUTPUT_DIR, "score.npy"), allow_pickle=True
+                ).item()
 
                 u = -torch.ones(len(lab2cname), model.visual.output_dim)
                 sm = nn.Softmax()
@@ -110,7 +115,7 @@ def solver(model, image, nimg, label, lab2cname):
                     if int(label[i]) not in ss:
                         u[int(label[i]), S] = 1
                     ss[int(label[i])] = 1
-            torch.save(u.t().repeat(1, 1), f'weights/{dataset}_{args.seed}_{args.opts}_{label[0]}.pth')
+            torch.save(u.t().repeat(1, 1), f"{weight_dir}/{dataset}_{args.seed}_{args.opts}_{label[0]}.pth")
             return u.t().repeat(1, 1)
             
 


### PR DESCRIPTION
Currently, the file `score.npy` and weight directory `weights/` are located in the directory `CPL/CPL/`, where `train_cf.py` is called.

However, this creates a bug when at least two processes of `train_cf.py` are run at the same time for different datasets. In this case, the score file and weights based on one process would be overwritten by other processes, resulting in score and weight files not associated with the process's dataset.

This PR proposes to fix the bug by specifying that the score and weight files should be saved and loaded from each process's output directory.