### PR TITLE
Feature/load trained model files when eval only

### DIFF
--- a/CPL/train_cf.py
+++ b/CPL/train_cf.py
@@ -78,6 +78,10 @@ def reset_cfg(cfg, args):
     if args.head:
         cfg.MODEL.HEAD.NAME = args.head
 
+    cfg.EVAL_ONLY = args.eval_only
+    if args.eval_only:
+        cfg.MODEL_DIR = args.model_dir
+
 
 def extend_cfg(cfg):
     """

--- a/CPL/trainers/cocoopcf.py
+++ b/CPL/trainers/cocoopcf.py
@@ -100,7 +100,14 @@ class PromptLearner(nn.Module):
 
 
         self.ctx = nn.Parameter(ctx_vectors)
-        self.u = nn.Parameter(torch.ones(vis_dim, len(classnames)))
+        if cfg.EVAL_ONLY:
+            score = np.load(
+                osp.join(cfg.MODEL_DIR, "score.npy"), allow_pickle=True
+            ).item()
+            u_n_cls = len(score.keys())
+        else:
+            u_n_cls = len(classnames)
+        self.u = nn.Parameter(torch.ones(vis_dim, u_n_cls))
 
         self.meta_net = nn.Sequential(OrderedDict([
             ("linear1", nn.Linear(vis_dim, vis_dim // 16)),

--- a/CPL/trainers/cocoopcf.py
+++ b/CPL/trainers/cocoopcf.py
@@ -217,10 +217,13 @@ class CustomCLIP(nn.Module):
         self.dtype = clip_model.dtype
         self.classnames = classnames
         self.vis_dim = clip_model.visual.output_dim
-        self.ScoreDict = init_score_dict(classnames, cfg.OUTPUT_DIR)    ## generate score dictionary
-        # self.ScoreDict = np.load(
-        #     osp.join(cfg.OUTPUT_DIR, "score.npy"), allow_pickle=True
-        # ).item()
+        if cfg.EVAL_ONLY:
+            # Load score.npy from the trained model.
+            self.ScoreDict = np.load(
+                osp.join(cfg.MODEL_DIR, "score.npy"), allow_pickle=True
+            ).item()
+        else:
+            self.ScoreDict = init_score_dict(classnames, cfg.OUTPUT_DIR)  # generate score dictionary
 
 
     def forward(self, image, ustar=None, nimgs=None, label=None):
@@ -315,8 +318,12 @@ class CoCoOpcf(TrainerX):
 
         self.scaler = GradScaler() if cfg.TRAINER.COCOOP.PREC == "amp" else None
 
+        if cfg.EVAL_ONLY:
+            score_dir = cfg.MODEL_DIR
+        else:
+            score_dir = cfg.OUTPUT_DIR
         self.ScoreDict = np.load(
-            osp.join(cfg.OUTPUT_DIR, "score.npy"), allow_pickle=True
+            osp.join(score_dir, "score.npy"), allow_pickle=True
         ).item()
         print(f"Loading score dictionary")
 


### PR DESCRIPTION
Currently, the score object is always initialized and then saved to (loaded from) `cfg.OUTPUT_DIR`. However, when running evaluation, the model directory (where `score.npy` is located) may be different from the evaluation result output directory.

This PR proposes to always load `score.npy` from the model directory during an evaluation-only run.

Also, currently the parameter `u` in `PromptLearner` has dimensions based on the number of classes in the dataset. However, the evaluation dataset may have different number of classes compared to the training dataset, causing an dimension-mismatch error when loading the state dict for `u`.

This PR proposes that, during an evaluation-only run, the dimension of `u` should be initialized based on the number of classes in `score.npy` from a trained model.